### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,14 +2,14 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
 )
 
-add_library(SimpleCollections INTERFACE ${SOURCES})
+add_library(SimpleCollections ${SOURCES})
 
 
 target_compile_definitions(SimpleCollections
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
-target_include_directories(SimpleCollections INTERFACE
+target_include_directories(SimpleCollections PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(SimpleCollections INTERFACE pico_stdlib pico_sync)
+target_link_libraries(SimpleCollections PUBLIC pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -2,14 +2,14 @@ file(GLOB SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
 )
 
-add_library(SimpleCollections ${SOURCES})
+add_library(SimpleCollections INTERFACE ${SOURCES})
 
 
 target_compile_definitions(SimpleCollections
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
-target_include_directories(SimpleCollections PUBLIC
+target_include_directories(SimpleCollections INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(SimpleCollections PUBLIC pico_stdlib pico_sync)
+target_link_libraries(SimpleCollections INTERFACE pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,15 +1,17 @@
-file(GLOB SOURCES 
-        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
-)
+cmake_minimum_required(VERSION 3.13)
 
-add_library(SimpleCollections ${SOURCES})
+add_library(SimpleCollections
+        ../src/SCCircularBuffer.cpp
+        ../src/SCThreadingSupport.cpp
+        ../src/SimpleCollections.cpp
+)
 
 
 target_compile_definitions(SimpleCollections
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 target_include_directories(SimpleCollections PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
+        ../src
 )
 
 target_link_libraries(SimpleCollections PUBLIC pico_stdlib pico_sync)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,14 +1,15 @@
-add_library(SimpleCollections
-        ../src/SCCircularBuffer.cpp
-        ../src/SCThreadingSupport.cpp
-        ../src/SimpleCollections.cpp
+file(GLOB SOURCES 
+        "${CMAKE_CURRENT_LIST_DIR}/../src/*.cpp"
 )
+
+add_library(SimpleCollections ${SOURCES})
+
 
 target_compile_definitions(SimpleCollections
         PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 target_include_directories(SimpleCollections PUBLIC
-        ${PROJECT_SOURCE_DIR}/lib/SimpleCollections/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(SimpleCollections PUBLIC pico_stdlib pico_sync)

--- a/src/SCCircularBuffer.h
+++ b/src/SCCircularBuffer.h
@@ -8,7 +8,7 @@
 
 #include <string.h>
 #include <inttypes.h>
-#include <SCThreadingSupport.h>
+#include "SCThreadingSupport.h"
 
 /**
  * @file SCCircularBuffer.h

--- a/src/SimpleCollections.h
+++ b/src/SimpleCollections.h
@@ -13,7 +13,7 @@
 
 #include <string.h>
 #include <inttypes.h>
-#include <SCThreadingSupport.h>
+#include "SCThreadingSupport.h"
 
 namespace tccollection {
 


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.